### PR TITLE
Fix build on Windows

### DIFF
--- a/src/main/java/com/github/lehjr/numina/util/string/MuseStringUtils.java
+++ b/src/main/java/com/github/lehjr/numina/util/string/MuseStringUtils.java
@@ -66,7 +66,7 @@ public class MuseStringUtils {
 
 */
     // milli, micro, etc.
-    public static final char[] smallSuffixes = {'m', 'μ', 'n', 'p', 'f', 'a', 'z', 'y'};
+    public static final char[] smallSuffixes = {'m', '\u00B5', 'n', 'p', 'f', 'a', 'z', 'y'};
     public static final char[] bigSuffixes = {'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'};
 
     public static String extractName(ResourceLocation resource) {


### PR DESCRIPTION
The mu unicode charcater was breaking the build on my windows computer using the provided gradle wrapper.